### PR TITLE
Rewrote Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,19 @@
-CC=gcc
-CFLAGS="-Wall -Wextra -Werror -pedantic"
+CC     := gcc
+CFLAGS += -Wall -Wextra -Werror -Wno-unused-result -pedantic
 
-debug:clean
-	$(CC) $(CFLAGS) -fsanitize=leak,address,undefined -g -o vmd example.c
-stable:clean
-	$(CC) $(CFLAGS) -O3 -o vmd example.c
+DEBUG_CFLAGS   ?= -Og -ggdb3 -fsanitize=address,undefined,leak 
+RELEASE_CFLAGS ?= -O3 -flto
+
+ifeq ($(DEBUG), 1)
+CFLAGS += $(DEBUG_CFLAGS)
+else
+CFLAGS += $(RELEASE_CFLAGS)
+endif
+
+.PHONY: clean
+
+vmd: example.c
+	$(CC) $(CFLAGS) -o $@ $< 
+
 clean:
 	rm -vfr *~ vmd


### PR DESCRIPTION
- `$(CFLAGS)` can be appended from CLI
- Added `-Wno-unused-result` to `$(CFLAGS)`
- Added `$(DEBUG)` option instead of  `debug` rule
- Added `-flto` for stable release
- Added `-Og -ggdb3` for debug mode
- Removed `stable` and `debug` rule

To compile with debugging flags
```c
make vmd DEBUG=1
```
In the absence of DEBUG, `$(RELEASE_CFLAGS)` with be used.
**Always** invoke `make vmd` with DEBUG mode changes `clean`